### PR TITLE
Lharrison/rate limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apk add --no-cache bash
 ARG user=joker
 ARG home=/home/$user
 ARG group=thejokers
+ARG RATE_LIMIT_TIME=10
+ARG RATE_LIMIT_MAX=1000
+ARG RATE_LIMIT_MESSAGE='Too many requests, please try again later.'
 RUN addgroup -S $group
 RUN adduser \
     --disabled-password \

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "apollo-server-core": "^3.6.3",
         "apollo-server-express": "^3.6.3",
         "express": "^4.17.3",
+        "express-rate-limit": "^6.3.0",
         "graphql": "^16.3.0",
         "graphql-subscriptions": "^2.0.0",
         "graphql-ws": "^5.6.3",
@@ -593,6 +594,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.3.0.tgz",
+      "integrity": "sha512-932Io1VGKjM3ppi7xW9sb1J5nVkEJSUiOtHw2oE+JyHks1e+AXuOBSXbJKM0mcXwEnW1TibJibQ455Ow1YFjfg==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1643,6 +1655,12 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
+    },
+    "express-rate-limit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.3.0.tgz",
+      "integrity": "sha512-932Io1VGKjM3ppi7xW9sb1J5nVkEJSUiOtHw2oE+JyHks1e+AXuOBSXbJKM0mcXwEnW1TibJibQ455Ow1YFjfg==",
+      "requires": {}
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apollo-server-core": "^3.6.3",
     "apollo-server-express": "^3.6.3",
     "express": "^4.17.3",
+    "express-rate-limit": "^6.3.0",
     "graphql": "^16.3.0",
     "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.6.3",

--- a/server.js
+++ b/server.js
@@ -6,25 +6,27 @@ import { ApolloServerPluginDrainHttpServer } from "apollo-server-core";
 import { WebSocketServer } from "ws";
 import { useServer } from "graphql-ws/lib/use/ws";
 import { pubsub } from "./api/graphql/pubsub.js";
-import { rateLimit } from 'express-rate-limit'
+import { rateLimit } from "express-rate-limit";
 
 (async function () {
   const app = express();
   const httpServer = createServer(app);
 
-	const RATE_LIMIT_TIME = process.env.RATE_LIMIT_TIME || 10; // in minutes
-	const RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX || 1000;
-	const RATE_LIMIT_MESSAGE = process.env.RATE_LIMIT_MESSAGE || 'Too many requests, please try again later.';
+  const RATE_LIMIT_TIME = process.env.RATE_LIMIT_TIME || 10; // in minutes
+  const RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX || 1000;
+  const RATE_LIMIT_MESSAGE =
+    process.env.RATE_LIMIT_MESSAGE ||
+    "Too many requests, please try again later.";
 
-	const limiter = rateLimit({
-		windowMs: RATE_LIMIT_TIME * 60 * 1000, // in minutes
-		max: RATE_LIMIT_MAX, // Limit each IP to n requests per `window` (default 400 per 10 minutes)
-		standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-		legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-		message: RATE_LIMIT_MESSAGE, // Message returned to the user
-	})
+  const limiter = rateLimit({
+    windowMs: RATE_LIMIT_TIME * 60 * 1000, // in minutes
+    max: RATE_LIMIT_MAX, // Limit each IP to n requests per `window` (default 400 per 10 minutes)
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    message: RATE_LIMIT_MESSAGE, // Message returned to the user
+  });
 
-	app.use(limiter)
+  app.use(limiter);
 
   // Creating the WebSocket server
   const wsServer = new WebSocketServer({

--- a/server.js
+++ b/server.js
@@ -6,10 +6,25 @@ import { ApolloServerPluginDrainHttpServer } from "apollo-server-core";
 import { WebSocketServer } from "ws";
 import { useServer } from "graphql-ws/lib/use/ws";
 import { pubsub } from "./api/graphql/pubsub.js";
+import { rateLimit } from 'express-rate-limit'
 
 (async function () {
   const app = express();
   const httpServer = createServer(app);
+
+	const RATE_LIMIT_TIME = process.env.RATE_LIMIT_TIME || 10; // in minutes
+	const RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX || 1000;
+	const RATE_LIMIT_MESSAGE = process.env.RATE_LIMIT_MESSAGE || 'Too many requests, please try again later.';
+
+	const limiter = rateLimit({
+		windowMs: RATE_LIMIT_TIME * 60 * 1000, // in minutes
+		max: RATE_LIMIT_MAX, // Limit each IP to n requests per `window` (default 400 per 10 minutes)
+		standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+		legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+		message: RATE_LIMIT_MESSAGE, // Message returned to the user
+	})
+
+	app.use(limiter)
 
   // Creating the WebSocket server
   const wsServer = new WebSocketServer({


### PR DESCRIPTION
## No associated Jira issue

### Description
Adding in rate limiting middleware

List of proposed changes:

- Add in ENV vars to control the middleware settings (Dockerfile and server.js)
- Add express-rate-limit middleware (package.json, lock)
- Configure rate limit middleware (server.js)

### What to test for/How to test
- locally you can test with 
`RATE_LIMIT_MAX=20 node server.js`
then hit an endpoint (localhost/graphql) with OPTION requests 20 times

### Additional Notes
Defaults are in both the server.js and the dockerfile to be flexible